### PR TITLE
avoid rerender

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { PureComponent } from 'react'
 import { number, string, object } from 'prop-types'
 import zxcvbn from 'zxcvbn'
 import styled from 'styled-components'
@@ -6,7 +6,7 @@ import styled from 'styled-components'
 import Meters from './meters'
 import { getStrengthColor, getStrengthText } from './utils/functions'
 
-const PasswordStrengthStyled = styled.div`
+const StrengthStyled = styled.div`
   width: 300px;
   display: flex;
   flex-direction: column;
@@ -24,29 +24,43 @@ const StrengthLabelStyled = styled.span`
   color: ${props => props.color};
 `
 
-const PasswordStrength = ({ width = 300, value, strengthColors, strengthTexts }) => {
+class Strength extends PureComponent {
+  render() {
+    const { width = 300, showLabel, score, strengthColors, strengthTexts } = this.props
+    const maxMeters = 4
+    const meterWidth = width / maxMeters
+    const strengthColor = getStrengthColor(score, strengthColors)
+    const strengthText = getStrengthText(score, strengthTexts)
+    const meterValue = score === 0 ? maxMeters : score
+
+    return (
+      <StrengthStyled>
+        <div className='meters'>
+          <Meters
+            meterValue={meterValue}
+            meterWidth={meterWidth}
+            backgroundColor={strengthColor}
+          />
+        </div>
+        {showLabel &&
+          <StrengthLabelStyled color={strengthColor}>
+            {strengthText}
+          </StrengthLabelStyled>
+        }
+      </StrengthStyled>
+    )
+  }
+}
+
+const PasswordStrength = ({ value, ...props }) => {
   const { score } = zxcvbn(value)
-  const maxMeters = 4
-  const meterWidth = width / maxMeters
-  const strengthColor = getStrengthColor(score, strengthColors)
-  const strengthText = getStrengthText(score, strengthTexts)
-  const meterValue = score === 0 ? maxMeters : score
 
   return (
-    <PasswordStrengthStyled>
-      <div className='meters'>
-        <Meters
-          meterValue={meterValue}
-          meterWidth={meterWidth}
-          backgroundColor={strengthColor}
-        />
-      </div>
-      {value &&
-        <StrengthLabelStyled color={strengthColor}>
-          {strengthText}
-        </StrengthLabelStyled>
-      }
-    </PasswordStrengthStyled>
+    <Strength
+      score={score}
+      showLabel={!!value}
+      {...props}
+    />
   )
 }
 

--- a/src/meters.js
+++ b/src/meters.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import Meter from './meter'
 
 const Meters = ({ meterValue, meterWidth, backgroundColor }) => (
-  Array.from(Array(meterValue).keys()).map(index => (
+  Array.from({ length: meterValue }, (_, index) => (
     <Meter
       key={index}
       width={meterWidth}


### PR DESCRIPTION
* Avoid rerender when score is the same
* Using only `Array.from` API, not necessary `Array#values`

# Benchmark (using [react-component-benchmark](https://github.com/paularmstrong/react-component-benchmark))

## Component

![capturar](https://user-images.githubusercontent.com/8618687/45593222-b123b200-b957-11e8-871d-469c52ac0c61.PNG)

## PureComponent + Strength component split
![capturar2](https://user-images.githubusercontent.com/8618687/45593223-c698dc00-b957-11e8-9a9f-a4dd075117fa.PNG)
